### PR TITLE
Support $GERBIL_GSC in build0.scm

### DIFF
--- a/src/build/build0.scm
+++ b/src/build/build0.scm
@@ -9,7 +9,7 @@
 (define (compile modf)
   (displayln "... compile " modf)
   (let ((proc (open-process
-               (list path: "gsc"
+               (list path: (getenv "GERBIL_GSC" "gsc")
                      arguments: (list "-cc-options" "--param max-gcse-memory=300000000" modf)
                      stdout-redirection: #f))))
     (if (not (zero? (process-status proc)))


### PR DESCRIPTION
This makes a full build possible with $GERBIL_GSC override.